### PR TITLE
DataHub Jupyter VM

### DIFF
--- a/ubuntu/appdb/datahub-jupyter-ubuntu-20.04.yaml
+++ b/ubuntu/appdb/datahub-jupyter-ubuntu-20.04.yaml
@@ -1,10 +1,10 @@
 ---
 appdb:
-  version: 2022.06.02
+  version: 2022.07.06
   expireson: 6
-  notes: First version of the appliance 
-  url: https://api.cloud.ifca.es:8080/swift/v1/egi_endorsed_vas/DataHub-Jupyter-Ubuntu.20.04-2022.06.02.ova
-  sha512: "6105c4a591ac89bcdf2681e15209aaf88c77c8ade78c7c618301f3238660c3acea5c97dcd4eda2020fc8cfba7438c8b3daced588fd67dc3338ec1c0579523cc5"
+  notes: First working version of the appliance
+  url: "https://api.cloud.ifca.es:8080/swift/v1/egi_endorsed_vas/DataHub-Jupyter-Ubuntu.20.04-2022.07.06.ova"
+  sha512: "a0b4f3890564abf7a77b86c028282bf8f256461cd692cb8fbe13ebe5fb2aee7090227b67f27b7093888be50346d7c8726216209027206e3a32e54ae712a2a48e"
   arch: x86_64
   os:
     family: Linux

--- a/ubuntu/appdb/datahub-jupyter-ubuntu-20.04.yaml
+++ b/ubuntu/appdb/datahub-jupyter-ubuntu-20.04.yaml
@@ -1,10 +1,10 @@
 ---
 appdb:
-  version: 2022.07.06
+  version: 2022.08.01
   expireson: 6
-  notes: First working version of the appliance
-  url: "https://api.cloud.ifca.es:8080/swift/v1/egi_endorsed_vas/DataHub-Jupyter-Ubuntu.20.04-2022.07.06.ova"
-  sha512: "a0b4f3890564abf7a77b86c028282bf8f256461cd692cb8fbe13ebe5fb2aee7090227b67f27b7093888be50346d7c8726216209027206e3a32e54ae712a2a48e"
+  notes: Update to avoid the use of plain HTTP
+  url: "https://api.cloud.ifca.es:8080/swift/v1/egi_endorsed_vas/DataHub-Jupyter-Ubuntu.20.04-2022.08.01.ova"
+  sha512: "adeb2f1c02fa8e08fd0e26846d566229d3eca330454dc29c3906e8bf797b82033a4bdcffcc3879640d9784bd2d9e5dedaefd4417b45fa4c7276a4117725a8ed0"
   arch: x86_64
   os:
     family: Linux

--- a/ubuntu/appdb/datahub-jupyter-ubuntu-20.04.yaml
+++ b/ubuntu/appdb/datahub-jupyter-ubuntu-20.04.yaml
@@ -1,0 +1,16 @@
+---
+appdb:
+  version: 2022.06.02
+  expireson: 6
+  notes: First version of the appliance 
+  url: https://api.cloud.ifca.es:8080/swift/v1/egi_endorsed_vas/DataHub-Jupyter-Ubuntu.20.04-2022.06.02.ova
+  sha512: "6105c4a591ac89bcdf2681e15209aaf88c77c8ade78c7c618301f3238660c3acea5c97dcd4eda2020fc8cfba7438c8b3daced588fd67dc3338ec1c0579523cc5"
+  arch: x86_64
+  os:
+    family: Linux
+    name: Ubuntu
+    version: '20.04'
+  ram:
+    minimum: 1GB
+  format: OVA
+  hypervisor: VirtualBox

--- a/ubuntu/datahub-jupyter-ubuntu-20.04.json
+++ b/ubuntu/datahub-jupyter-ubuntu-20.04.json
@@ -25,7 +25,7 @@
       "ssh_username": "ubuntu",
       "type": "virtualbox-iso",
       "guest_additions_mode": "disable",
-      "vm_name": "DataHub-Jupyter-Ubuntu.20.04-2022.04.25"
+      "vm_name": "DataHub-Jupyter-Ubuntu.20.04-2022.06.02"
     }
   ],
   "provisioners": [

--- a/ubuntu/datahub-jupyter-ubuntu-20.04.json
+++ b/ubuntu/datahub-jupyter-ubuntu-20.04.json
@@ -1,0 +1,44 @@
+{
+  "builders": [
+    {
+      "boot_command": [
+	"<esc><esc><f6><esc><wait>",
+        " autoinstall ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ",
+	" PACKER_USER=ubuntu PACKER_AUTHORIZED_KEY={{ .SSHPublicKey | urlquery }}",
+        "<wait><enter>"
+      ],
+      "boot_wait": "5s",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "1024" ]
+      ],
+      "disk_size": 8000,
+      "format": "ova",
+      "guest_os_type": "Ubuntu_64",
+      "http_directory": "httpdir",
+      "http_port_max": 8550,
+      "http_port_min": 8500,
+      "iso_url": "https://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso",
+      "iso_checksum": "sha256:28ccdb56450e643bad03bb7bcf7507ce3d8d90e8bf09e38f6bd9ac298a98eaad",
+      "ssh_timeout": "20m",
+      "ssh_clear_authorized_keys": true,
+      "shutdown_command": "sudo -- sh -c 'rm /etc/sudoers.d/99-egi-installation && shutdown -h now'",
+      "ssh_username": "ubuntu",
+      "type": "virtualbox-iso",
+      "guest_additions_mode": "disable",
+      "vm_name": "DataHub-Jupyter-Ubuntu.20.04-2022.04.25"
+    }
+  ],
+  "provisioners": [
+    {
+      "playbook_file": "provisioners/init.yaml",
+      "type": "ansible",
+      "user": "ubuntu"
+    },
+    {
+      "pause_before": "30s",
+      "playbook_file": "provisioners/datahub-jupyter.yaml",
+      "type": "ansible",
+      "user": "ubuntu"
+    }
+  ]
+}

--- a/ubuntu/datahub-jupyter-ubuntu-20.04.json
+++ b/ubuntu/datahub-jupyter-ubuntu-20.04.json
@@ -25,7 +25,7 @@
       "ssh_username": "ubuntu",
       "type": "virtualbox-iso",
       "guest_additions_mode": "disable",
-      "vm_name": "DataHub-Jupyter-Ubuntu.20.04-2022.06.02"
+      "vm_name": "DataHub-Jupyter-Ubuntu.20.04-2022.07.06"
     }
   ],
   "provisioners": [

--- a/ubuntu/datahub-jupyter-ubuntu-20.04.json
+++ b/ubuntu/datahub-jupyter-ubuntu-20.04.json
@@ -19,13 +19,13 @@
       "http_port_min": 8500,
       "iso_url": "https://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso",
       "iso_checksum": "sha256:28ccdb56450e643bad03bb7bcf7507ce3d8d90e8bf09e38f6bd9ac298a98eaad",
-      "ssh_timeout": "20m",
+      "ssh_timeout": "25m",
       "ssh_clear_authorized_keys": true,
       "shutdown_command": "sudo -- sh -c 'rm /etc/sudoers.d/99-egi-installation && shutdown -h now'",
       "ssh_username": "ubuntu",
       "type": "virtualbox-iso",
       "guest_additions_mode": "disable",
-      "vm_name": "DataHub-Jupyter-Ubuntu.20.04-2022.07.06"
+      "vm_name": "DataHub-Jupyter-Ubuntu.20.04-2022.08.01"
     }
   ],
   "provisioners": [

--- a/ubuntu/provisioners/datahub-jupyter.yaml
+++ b/ubuntu/provisioners/datahub-jupyter.yaml
@@ -29,6 +29,17 @@
       ansible.builtin.apt:
         name: [nginx, acl]
         state: present
+    - name: Install foo
+      community.general.snap:
+        channel: latest
+        classic: true
+        name:
+          - certbot
+    - name: Make certbot usable
+      file:
+        path: /usr/bin/certbot
+        src: /snap/bin/certbot
+        state: link
 
 # set things up as jovyan
 - hosts: all
@@ -91,6 +102,20 @@
         enabled: yes
         name: jupyter
         daemon_reload: yes
+    - name: Add 406 error page
+      ansible.builtin.copy:
+        dest: /var/www/html/custom_406.html
+        content: |
+          <html>
+          <head></head><title>No ssl?</title>
+          <body>
+              <h1>Welcome to your Jupyter + Datahub VM</h1>
+              <h2>Where's my Notebook?</h2>
+              <p>You seem not to be running this server using HTTPS. This is not recommended!</p>
+              <p>Check the <a href="https://docs.egi.eu/users/tutorials/jupyter-datahub-virtual-machine/">tutorial documentation</a>
+              to learn how to enable HTTPS on this host or (only if strictly necessary) remove this error message.</p>
+          </body>
+          </html>
     - name: Reconfig nginx
       ansible.builtin.copy:
         dest: /etc/nginx/sites-available/default
@@ -101,11 +126,16 @@
 
             root /var/www/html;
 
+            error_page 406 /custom_406.html;
             index index.html index.htm index.nginx-debian.html;
 
             server_name _;
 
             location / {
+
+                if ( $https != 'on' ) {
+                    return 406;
+                }
                 proxy_pass http://127.0.0.1:8888/;
                 proxy_http_version 1.1;
                 proxy_set_header Upgrade $http_upgrade;
@@ -113,6 +143,10 @@
                 proxy_set_header Host $host;
                 proxy_read_timeout 86400;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            }
+            location = /custom_406.html {
+                root /var/www/html;
+                internal;
             }
           }
 

--- a/ubuntu/provisioners/datahub-jupyter.yaml
+++ b/ubuntu/provisioners/datahub-jupyter.yaml
@@ -1,0 +1,137 @@
+---
+- hosts: all
+  become: true
+  roles:
+    - cloud-init
+
+- hosts: all
+  become: true
+  tasks:
+    - name: Install oneclient
+      shell: |
+        # Install oneclient from the available script
+        curl -sS http://get.onedata.org/oneclient.sh | bash
+    - name: Setup the datahub directory
+      ansible.builtin.file:
+        path: /mnt/datahub
+        state: directory
+        mode: '0777'
+        owner: 1000
+    - name: Allow other for fuse
+      ansible.builtin.lineinfile:
+        path: /etc/fuse.conf
+        regexp: '^user_allow_other'
+        line: user_allow_other 
+    - name: mount helper
+      copy:
+        dest: /home/ubuntu/mount.sh
+        mode: '0755'
+        content: |
+          #!/bin/bash
+
+          # Personal token obtained from https://datahub.eu
+          ONECLIENT_TOKEN="<your DataHub token>"
+          # Closes oneprovider supporting your spaces
+          ONECLIENT_ONEPROVIDER="plg-cyfronet-01.datahub.egi.eu"
+
+          oneclient -H "$ONECLIENT_ONEPROVIDER" -t "$ONECLIENT_TOKEN" /mnt/datahub
+    - name: umount helper
+      copy:
+        dest: /home/ubuntu/umount.sh
+        mode: '0755'
+        content: |
+          #!/bin/bash
+
+          oneclient -u /mnt/datahub
+    - name: Add a jovyan user without sudo
+      user:
+        name: jovyan
+        comment: Jupyter user
+        shell: /bin/bash
+        uid: 1001
+    - name: Install micromamba
+      shell: |
+        wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+        mv bin/micromamba /usr/local/bin/micromamba
+    - name: install packages 
+      ansible.builtin.apt:
+        name: [nginx, acl]
+        state: present
+
+# set things up as jovyan
+- hosts: all
+  become: true
+  become_user: jovyan
+  tasks:
+    - name: create micromamba directory
+      ansible.builtin.file:
+        path: /home/jovyan/micromamba
+        state: directory
+        mode: '0755'
+    - name: create datahub directory as link
+      ansible.builtin.file:
+        dest: /home/jovyan/datahub
+        src: /mnt/datahub
+        state: link 
+        mode: '0755'
+    - name: Install jupyterhub using conda
+      shell: |
+        micromamba shell init --shell=bash --prefix=~/micromamba
+        micromamba install -y -c conda-forge -p /home/jovyan/micromamba jupyter jupyterlab 
+
+- hosts: all
+  become: true
+  tasks:
+    - name: Create jupyter unit
+      copy:
+        dest: /etc/systemd/system/jupyter.service 
+        content: |
+          [Unit]
+          Description=Jupyter Notebook
+
+          [Service]
+          Type=simple
+          PIDFile=/run/jupyter.pid
+          ExecStart=/home/jovyan/micromamba/bin/jupyter-lab --no-browser --notebook-dir=/home/jovyan
+          User=jovyan
+          Group=jovyan
+          Restart=always
+          RestartSec=10
+
+          [Install]
+          WantedBy=multi-user.target
+    - name: Enable jupyter
+      ansible.builtin.systemd: 
+        state: started
+        enabled: yes
+        name: jupyter
+        daemon_reload: yes
+    - name: Reconfig nginx
+      copy:
+        dest: /etc/nginx/sites-available/default
+        content: 
+          server {
+            listen 80 default_server;
+            listen [::]:80 default_server;
+
+            root /var/www/html;
+
+            index index.html index.htm index.nginx-debian.html;
+
+            server_name _;
+
+            location / {
+                proxy_pass http://127.0.0.1:8888/;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "Upgrade";
+                proxy_set_header Host $host;
+                proxy_read_timeout 86400;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            }
+          }
+
+- hosts: all
+  become: true
+  roles:
+    - cleanup

--- a/ubuntu/provisioners/datahub-jupyter.yaml
+++ b/ubuntu/provisioners/datahub-jupyter.yaml
@@ -21,24 +21,27 @@
       ansible.builtin.lineinfile:
         path: /etc/fuse.conf
         regexp: '^user_allow_other'
-        line: user_allow_other 
+        line: user_allow_other
     - name: mount helper
       copy:
         dest: /home/ubuntu/mount.sh
         mode: '0755'
+        owner: 1000
         content: |
           #!/bin/bash
 
           # Personal token obtained from https://datahub.eu
-          ONECLIENT_TOKEN="<your DataHub token>"
-          # Closes oneprovider supporting your spaces
-          ONECLIENT_ONEPROVIDER="plg-cyfronet-01.datahub.egi.eu"
+          ONECLIENT_ACCESS_TOKEN="<your DataHub token>"
+          # Closesr oneprovider supporting your spaces
+          ONECLIENT_PROVIDER_HOST="plg-cyfronet-01.datahub.egi.eu"
 
-          oneclient -H "$ONECLIENT_ONEPROVIDER" -t "$ONECLIENT_TOKEN" /mnt/datahub
+          # mount with allow_other so jovyan can access
+          oneclient -H "$ONECLIENT_PROVIDER_HOST" -t "$ONECLIENT_ACCESS_TOKEN"  -o allow_other /mnt/datahub
     - name: umount helper
       copy:
         dest: /home/ubuntu/umount.sh
         mode: '0755'
+        owner: 1000
         content: |
           #!/bin/bash
 
@@ -48,12 +51,18 @@
         name: jovyan
         comment: Jupyter user
         shell: /bin/bash
-        uid: 1001
+        uid: 1002
+    - name: create datahub directory as link
+      ansible.builtin.file:
+        dest: /home/jovyan/datahub
+        src: /mnt/datahub
+        state: link
+        mode: '0755'
     - name: Install micromamba
       shell: |
         wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
         mv bin/micromamba /usr/local/bin/micromamba
-    - name: install packages 
+    - name: install packages
       ansible.builtin.apt:
         name: [nginx, acl]
         state: present
@@ -68,23 +77,19 @@
         path: /home/jovyan/micromamba
         state: directory
         mode: '0755'
-    - name: create datahub directory as link
-      ansible.builtin.file:
-        dest: /home/jovyan/datahub
-        src: /mnt/datahub
-        state: link 
-        mode: '0755'
     - name: Install jupyterhub using conda
       shell: |
-        micromamba shell init --shell=bash --prefix=~/micromamba
-        micromamba install -y -c conda-forge -p /home/jovyan/micromamba jupyter jupyterlab 
+        micromamba install -y -c conda-forge -p /home/jovyan/micromamba jupyter jupyterlab jq
+    - name: Get micromamba env
+      shell: |
+        micromamba shell init --shell=bash --prefix=/home/jovyan/micromamba || true
 
 - hosts: all
   become: true
   tasks:
     - name: Create jupyter unit
       copy:
-        dest: /etc/systemd/system/jupyter.service 
+        dest: /etc/systemd/system/jupyter.service
         content: |
           [Unit]
           Description=Jupyter Notebook
@@ -92,6 +97,7 @@
           [Service]
           Type=simple
           PIDFile=/run/jupyter.pid
+          WorkingDirectory=/home/jovyan
           ExecStart=/home/jovyan/micromamba/bin/jupyter-lab --no-browser --notebook-dir=/home/jovyan
           User=jovyan
           Group=jovyan
@@ -101,7 +107,7 @@
           [Install]
           WantedBy=multi-user.target
     - name: Enable jupyter
-      ansible.builtin.systemd: 
+      ansible.builtin.systemd:
         state: started
         enabled: yes
         name: jupyter
@@ -109,7 +115,7 @@
     - name: Reconfig nginx
       copy:
         dest: /etc/nginx/sites-available/default
-        content: 
+        content:
           server {
             listen 80 default_server;
             listen [::]:80 default_server;

--- a/ubuntu/provisioners/datahub-jupyter.yaml
+++ b/ubuntu/provisioners/datahub-jupyter.yaml
@@ -9,55 +9,18 @@
   tasks:
     - name: Install oneclient
       shell: |
-        # Install oneclient from the available script
         curl -sS http://get.onedata.org/oneclient.sh | bash
-    - name: Setup the datahub directory
-      ansible.builtin.file:
-        path: /mnt/datahub
-        state: directory
-        mode: '0777'
-        owner: 1000
     - name: Allow other for fuse
       ansible.builtin.lineinfile:
         path: /etc/fuse.conf
         regexp: '^user_allow_other'
         line: user_allow_other
-    - name: mount helper
-      copy:
-        dest: /home/ubuntu/mount.sh
-        mode: '0755'
-        owner: 1000
-        content: |
-          #!/bin/bash
-
-          # Personal token obtained from https://datahub.eu
-          ONECLIENT_ACCESS_TOKEN="<your DataHub token>"
-          # Closesr oneprovider supporting your spaces
-          ONECLIENT_PROVIDER_HOST="plg-cyfronet-01.datahub.egi.eu"
-
-          # mount with allow_other so jovyan can access
-          oneclient -H "$ONECLIENT_PROVIDER_HOST" -t "$ONECLIENT_ACCESS_TOKEN"  -o allow_other /mnt/datahub
-    - name: umount helper
-      copy:
-        dest: /home/ubuntu/umount.sh
-        mode: '0755'
-        owner: 1000
-        content: |
-          #!/bin/bash
-
-          oneclient -u /mnt/datahub
     - name: Add a jovyan user without sudo
-      user:
+      ansible.builtin.user:
         name: jovyan
         comment: Jupyter user
         shell: /bin/bash
         uid: 1002
-    - name: create datahub directory as link
-      ansible.builtin.file:
-        dest: /home/jovyan/datahub
-        src: /mnt/datahub
-        state: link
-        mode: '0755'
     - name: Install micromamba
       shell: |
         wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
@@ -83,12 +46,28 @@
     - name: Get micromamba env
       shell: |
         micromamba shell init --shell=bash --prefix=/home/jovyan/micromamba || true
+    - name: mount helper
+      ansible.builtin.copy:
+        dest: /home/jovyan/mount.sh
+        mode: '0755'
+        content: |
+          #!/bin/bash
+
+          # Personal token obtained from https://datahub.eu
+          ONECLIENT_ACCESS_TOKEN="<your DataHub token>"
+          # Closest oneprovider supporting your spaces
+          ONECLIENT_PROVIDER_HOST="plg-cyfronet-01.datahub.egi.eu"
+
+          mkdir -p /home/jovyan/datahub
+
+          # mount with allow_other so jovyan can access
+          oneclient -H "$ONECLIENT_PROVIDER_HOST" -t "$ONECLIENT_ACCESS_TOKEN"  /home/jovyan/datahub
 
 - hosts: all
   become: true
   tasks:
     - name: Create jupyter unit
-      copy:
+      ansible.builtin.copy:
         dest: /etc/systemd/system/jupyter.service
         content: |
           [Unit]
@@ -98,7 +77,7 @@
           Type=simple
           PIDFile=/run/jupyter.pid
           WorkingDirectory=/home/jovyan
-          ExecStart=/home/jovyan/micromamba/bin/jupyter-lab --no-browser --notebook-dir=/home/jovyan
+          ExecStart=/home/jovyan/micromamba/bin/jupyter-lab --no-browser --notebook-dir=/home/jovyan --ServerApp.allow_remote_access=True --NotebookApp.allow_origin="*"
           User=jovyan
           Group=jovyan
           Restart=always
@@ -113,9 +92,9 @@
         name: jupyter
         daemon_reload: yes
     - name: Reconfig nginx
-      copy:
+      ansible.builtin.copy:
         dest: /etc/nginx/sites-available/default
-        content:
+        content: |
           server {
             listen 80 default_server;
             listen [::]:80 default_server;

--- a/ubuntu/ubuntu-20.04.json
+++ b/ubuntu/ubuntu-20.04.json
@@ -19,7 +19,7 @@
       "http_port_min": 8500,
       "iso_url": "https://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso",
       "iso_checksum": "sha256:28ccdb56450e643bad03bb7bcf7507ce3d8d90e8bf09e38f6bd9ac298a98eaad",
-      "ssh_timeout": "15m",
+      "ssh_timeout": "20m",
       "ssh_clear_authorized_keys": true,
       "shutdown_command": "sudo -- sh -c 'rm /etc/sudoers.d/99-egi-installation && shutdown -h now'",
       "ssh_username": "ubuntu",


### PR DESCRIPTION
New VM for integration of international providers that brings a Notebook deployment with a onedata client so users can get a browser based environment to test how the integration works.

