### PR TITLE
Build with Ubuntu 24.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ AppDB can then be updated with that information.
 
 #### Requirements
 
-From a base Ubuntu 22.04, you can get a working building environment by
+From a base Ubuntu 24.04, you can get a working building environment by
 installing `packer`, `ansible`, `qemu`, and `jq`, e.g.:
 
 ```shell
 # get up to date system
 $ sudo apt-get update && sudo apt-get upgrade -y
 # Install packer
-$ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+$ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo tee /etc/apt/trusted.gpg.d/hashicorp.asc
 $ sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
 $ sudo apt-get update && sudo apt-get install -y packer
 # Install other tools

--- a/builder/SCAI.tfvars
+++ b/builder/SCAI.tfvars
@@ -4,5 +4,5 @@ net_id = "c38b0272-637e-4665-a79c-1a37222b572c"
 # Flavor: medium 
 flavor_id = "73302761-40dc-4ced-91d6-7dd18524a82e"
 
-# Image: ubuntu 22.04
-image_id = "adeba762-ad84-406a-b082-dd055a27afb4"
+# Image: ubuntu 24.04
+image_id = "40df255c-1032-47f0-b52a-bd46ad462aa0"


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

We should be building new images with the latest Ubuntu 24.04 as discussed in https://github.com/EGI-Federation/fedcloud-vmi-templates/pull/84#issuecomment-2306646029

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
