### PR TITLE
fix sha512 checksum for ubuntu-22.04

### DIFF
--- a/ubuntu/appdb/ubuntu-22.04.yaml
+++ b/ubuntu/appdb/ubuntu-22.04.yaml
@@ -4,7 +4,7 @@ appdb:
   expireson: 6
   notes: Update to Ubuntu 22.04.5
   url: https://api.cloud.ifca.es:8080/swift/v1/egi_endorsed_vas/Ubuntu.22.04-2025.01.27.qcow2
-  sha512: "17d3ee51f7a393905e63168ebb82f9d9f28316065edd6ccdca25fd8d84dc2ebddb6c2de2484dfb6220ac55a14045ffb006fe9c919475a6f83f6b2a65cde1f2ee"
+  sha512: "556cb503eeabb8678a33d90ae70cbf37c15dfe4a94a18fa5c28085671cab211137f7809ddb1b769be2c81acf26e26877a1235a21645984e6cb83cfccf69357f4"
   arch: x86_64
   os:
     family: Linux


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

sha512 check sum computed on build time:

```bash
### BUILD-IMAGE: SUCCESS - qcow: Ubuntu.22.04-2025.01.27.qcow2 sha512sum: 556cb503eeabb8678a33d90ae70cbf37c15dfe4a94a18fa5c28085671cab211137f7809ddb1b769be2c81acf26e26877a1235a21645984e6cb83cfccf69357f4
### BUILD ENDED
```

xref https://github.com/EGI-Federation/fedcloud-vmi-templates/pull/103

For some reason a different checksum was added:
https://github.com/EGI-Federation/fedcloud-vmi-templates/blob/13295a995647aaeb56b9fabb605d5962e180b85e/ubuntu/appdb/ubuntu-22.04.yaml#L7

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
