### PR TITLE
Push images to new registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Deploy
         env:
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+          REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+          REGISTRY_PWD: ${{ secrets.REGISTRY_PWD }}
         run: |
           cd builder
           mkdir -p ~/.config/openstack
@@ -77,7 +79,12 @@ jobs:
                                    --oidc-access-token "$(cat .oidc_token)" \
                                    --ttl 1h --num-uses 2)"
           echo "::add-mask::$FEDCLOUD_LOCKER_TOKEN"
-          fedcloud secret put --locker-token "$FEDCLOUD_LOCKER_TOKEN" deploy "data=$REFRESH_TOKEN"
+          fedcloud secret put \
+              --locker-token "$FEDCLOUD_LOCKER_TOKEN" \
+              deploy \
+              "token=$REFRESH_TOKEN" \
+              "registry_user=$REGISTRY_USER" \
+              "registry_password=$REGISTRY_PWD"
           DEPLOY_SITE="$(yq -r .clouds.deploy.site clouds.yaml)"
           echo "DEPLOY_SITE=$DEPLOY_SITE" >> "$GITHUB_ENV"
           sed -i -e "s#%IMAGE%#${{ matrix.images }}#" cloud-init.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
           sed -i -e "s/%REF%/${{ github.sha }}/" cloud-init.yaml
           sed -i -e "s/%SHORT_REF%/$(git rev-parse --short HEAD)/" cloud-init.yaml
           sed -i -e "s/%FEDCLOUD_LOCKER_TOKEN%/$FEDCLOUD_LOCKER_TOKEN/" cloud-init.yaml
+          sed -i -e "s/%UPLOAD%/1/" cloud-init.yaml
           # terraform!
           terraform apply -auto-approve -var-file="$DEPLOY_SITE.tfvars"
       - name: Get VM ID

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,10 @@
 name: Build images that changed
 
 on:
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   image-list:
@@ -68,6 +71,7 @@ jobs:
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
           REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
           REGISTRY_PWD: ${{ secrets.REGISTRY_PWD }}
+          UPLOAD: ${{ github.event_name == 'push' }}
         run: |
           cd builder
           mkdir -p ~/.config/openstack
@@ -92,7 +96,7 @@ jobs:
           sed -i -e "s/%REF%/${{ github.sha }}/" cloud-init.yaml
           sed -i -e "s/%SHORT_REF%/$(git rev-parse --short HEAD)/" cloud-init.yaml
           sed -i -e "s/%FEDCLOUD_LOCKER_TOKEN%/$FEDCLOUD_LOCKER_TOKEN/" cloud-init.yaml
-          sed -i -e "s/%UPLOAD%/1/" cloud-init.yaml
+          sed -i -e "s/%UPLOAD%/$UPLOAD/" cloud-init.yaml
           # terraform!
           terraform apply -auto-approve -var-file="$DEPLOY_SITE.tfvars"
       - name: Get VM ID

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,11 +121,12 @@ jobs:
             cat "${{ steps.terraform-vm-id.outputs.stdout }}"
             echo "BUILDEOF"
           } >> "$GITHUB_OUTPUT"
-          outcome=$( (grep "^### BUILD-IMAGE: " \
-                           "${{ steps.terraform-vm-id.outputs.stdout }}" \
-                      || echo "ERROR") \
-                    | cut -f2 -d":" | cut -f1 -d"-" | tr -d " ")
-          echo "outcome=$outcome" >> "$GITHUB_OUTPUT"
+          (
+            grep "^### BUILD-RESULT: " \
+               "${{ steps.terraform-vm-id.outputs.stdout }}" \
+               || echo ': {"status": "ERROR"}' \
+          ) | cut -f2- -d":" > outcome.json
+          echo "outcome=$(jq -r .status < outcome.json)" >> "$GITHUB_OUTPUT"
       - name: Update PR with build status
         uses: actions/github-script@v7
         with:
@@ -154,7 +155,9 @@ jobs:
               repo: context.repo.repo,
               body: output
             })
-      # Now create the new files and commit them? or PR them?
+      - name: Set Status
+        if: steps.process-output.outputs.outcome != 'SUCCESS'
+        run: exit 1
       - name: Delete VM
         if: always()
         env:

--- a/builder/build-image.sh
+++ b/builder/build-image.sh
@@ -53,7 +53,9 @@ mkdir -p /etc/openstack/
 cp builder/clouds.yaml /etc/openstack/clouds.yaml
 TMP_SECRETS="$(mktemp)"
 fedcloud secret get --locker-token "$FEDCLOUD_SECRET_LOCKER" \
-        deploy data >"$TMP_SECRETS" && mv "$TMP_SECRETS"  .refresh_token
+        deploy -f json >"$TMP_SECRETS" && mv "$TMP_SECRETS" secrets.json
+
+jq -r '.token' < secrets.json > .refresh_token
 
 # monitor ourselves
 systemctl start notify

--- a/builder/build-image.sh
+++ b/builder/build-image.sh
@@ -114,7 +114,7 @@ if tools/build.sh "$IMAGE"; then
 
     # All going well, upload the VMI in the registry
     # this should be done only if this is a push to main
-    if test "$UPLOAD" -eq 1; then
+    if test "$UPLOAD" == "true"; then
             builder/upload.sh "$IMAGE" secrets.json
     fi
     echo "### BUILD-RESULT: $(jq -cn --arg status "SUCCESS" \

--- a/builder/cloud-init.yaml
+++ b/builder/cloud-init.yaml
@@ -36,6 +36,7 @@ write_files:
       COMMIT_SHA="%REF%"
       IMAGE="%IMAGE%"
       FEDCLOUD_LOCKER_TOKEN="%FEDCLOUD_LOCKER_TOKEN%"
+      UPLOAD="%UPLOAD%"
 
       # get the repo code and untar at cwd
       curl -L -H "Accept: application/vnd.github.v3+raw" \
@@ -46,7 +47,7 @@ write_files:
       ansible-galaxy role install -p /var/tmp/egi/ubuntu/provisioners/roles/ grycap.docker
 
       # build image
-      builder/build-image.sh "$IMAGE" "$FEDCLOUD_LOCKER_TOKEN" > /var/log/image-build.log 2>&1
+      builder/build-image.sh "$IMAGE" "$FEDCLOUD_LOCKER_TOKEN" "$UPLOAD" > /var/log/image-build.log 2>&1
     path: /var/lib/cloud/scripts/per-boot/build.sh
     permissions: '0755'
   - content: |

--- a/builder/upload.sh
+++ b/builder/upload.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Uploads an image to the registry
+# First argument is the image description
+# Second is the secrets file
+
+set -e
+
+IMAGE="$1"
+SECRETS="$2"
+
+# Configuration, this may be passed as input
+REGISTRY="registry.egi.eu"
+PROJECT="egi_vm_images"
+
+# get oras
+# See https://oras.land/docs/installation
+VERSION="1.2.2"
+curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz"
+mkdir -p oras-install/
+tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/
+export PATH="$PWD/oras-install:$PATH"
+
+QEMU_SOURCE_ID=$(hcl2tojson "$IMAGE" | jq -r '.source[0].qemu | keys[]')
+VM_NAME=$(hcl2tojson "$IMAGE" \
+	| jq -r '.source[0].qemu.'"$QEMU_SOURCE_ID"'.vm_name')
+
+REPOSITORY=$(echo "$VM_NAME" | cut -f1 -d"." | tr '[:upper:]' '[:lower:]')
+TAG=$(echo "$VM_NAME" | cut -f2- -d".")
+
+OUTPUT_DIR="$(dirname "$IMAGE")/output-$QEMU_SOURCE_ID"
+QCOW_FILE="$OUTPUT_DIR/$VM_NAME.qcow2"
+
+# these may be handy
+ls -lh "$QCOW_FILE"
+# SHA="$(sha512sum -z "$QCOW_FILE" | cut -f1 -d" ")"
+
+MANIFEST_OUTPUT="$(hcl2tojson "$IMAGE" | \
+        jq -r '.build[0]."post-processor"[0].manifest.output')"
+
+# TODO(enolfc) need to figure out how to actually include metadata
+# into harbor, the annotation file here should follow this format
+# https://oras.land/docs/how_to_guides/manifest_annotations
+jq '.builds[0].custom_data' <"$(dirname "$IMAGE")/$MANIFEST_OUTPUT" \
+        >"$OUTPUT_DIR/annotation.json"
+
+REPOSITORY=$(jq -r '.os_distro' "$OUTPUT_DIR/annotation.json")
+
+# Now do the upload to registry
+# tell oras that we have a home
+# otherwise it will fail with
+# Error: failed to get user home directory: $HOME is not defined
+export HOME="$PWD"
+jq -r '.registry_password' "$SECRETS" | \
+        oras login -u "$(jq -r '.registry_user' "$SECRETS")"  \
+        --password-stdin "$REGISTRY"
+oras push --artifact-type application/application-x-qemu-disk \
+        "$REGISTRY/$PROJECT/$REPOSITORY:$TAG" "$QCOW_FILE"


### PR DESCRIPTION

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Uploads the images that changed to the new [EGI Artefact Registry](https://registry.egi.eu).

Stops using object storage as the temporary place where to upload images that are built and instead once tested ok with IM and when pushing to `main` branch, it pushes the resulting image to the registry.

It assumes images have a manifest with some metadata, e.g. for ubuntu 24.04:
```
  post-processor "manifest" {
    output = "manifest.json"
    strip_path = true
    custom_data = {
      os_distro = "ubuntu"
      os_version = "24.04"
      os_type = "linux"
      architecture = "x86_64"
    }
  }
```

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :** #106
