### PR TITLE
Add Ubuntu 26.04 LTS (Resolute Raccoon) image template

### DIFF
--- a/ubuntu/ubuntu-26.04.pkr.hcl
+++ b/ubuntu/ubuntu-26.04.pkr.hcl
@@ -1,0 +1,93 @@
+packer {
+  required_plugins {
+    ansible = {
+      source  = "github.com/hashicorp/ansible"
+      version = "~> 1"
+    }
+    qemu = {
+      source  = "github.com/hashicorp/qemu"
+      version = "~> 1"
+    }
+  }
+}
+
+variable "SSH_PRIVATE_KEY_FILE" {
+  type    = string
+  default = ""
+}
+
+variable "SSH_PUB_KEY" {
+  type    = string
+  default = ""
+}
+
+variable "image_tag" {
+  type    = string
+  default = ""
+}
+
+source "qemu" "ubuntu_26_04" {
+  boot_command              = [
+    "c<wait>",
+    "linux /casper/vmlinuz --- autoinstall ds=\"nocloud-net;seedfrom=http://{{ .HTTPIP }}:{{ .HTTPPort }}/\"",
+    " PACKER_USER=ubuntu PACKER_AUTHORIZED_KEY={{ `${var.SSH_PUB_KEY}` | urlquery }}",
+    "<enter><wait>",
+    "initrd /casper/initrd",
+    "<enter><wait>",
+    "boot",
+    "<enter>"
+  ]
+  boot_wait                 = "6s"
+  disk_size                 = 8000
+  format                    = "qcow2"
+  headless                  = true
+  http_directory            = "httpdir"
+  http_port_max             = 8550
+  http_port_min             = 8500
+  iso_checksum              = "sha256:dec49008a71f6098d0bcfc822021f4d042d5f2db279e4d75bdd981304f1ca5d9"
+  iso_url                   = "https://releases.ubuntu.com/26.04/ubuntu-26.04-live-server-amd64.iso"
+  memory                    = 2048
+  qemuargs                  = [["-cpu", "host"]]
+  shutdown_command          = "sudo -- sh -c 'rm /etc/sudoers.d/99-egi-installation && shutdown -h now'"
+  ssh_clear_authorized_keys = true
+  ssh_private_key_file      = "${var.SSH_PRIVATE_KEY_FILE}"
+  ssh_timeout               = "20m"
+  ssh_username              = "ubuntu"
+  vm_name                   = "Ubuntu.26.04-${var.image_tag}"
+}
+
+build {
+  sources = ["source.qemu.ubuntu_26_04"]
+
+  provisioner "ansible" {
+    extra_arguments = ["--extra-vars", "ansible_python_interpreter=/usr/bin/python3"]
+    playbook_file   = "provisioners/init.yaml"
+    use_proxy       = false
+    user            = "ubuntu"
+  }
+
+  provisioner "ansible" {
+    extra_arguments = ["--extra-vars", "ansible_python_interpreter=/usr/bin/python3"]
+    pause_before    = "30s"
+    playbook_file   = "provisioners/base.yaml"
+    use_proxy       = false
+    user            = "ubuntu"
+  }
+
+  provisioner "shell" {
+    script = "provisioners/cleanup.sh"
+  }
+
+  post-processor "manifest" {
+    output = "manifest.json"
+    strip_path = true
+    custom_data = {
+      "org.openstack.glance.os_distro" = "ubuntu"
+      "org.openstack.glance.os_admin_user" = "ubuntu"
+      "org.openstack.glance.os_version" = "26.04"
+      "org.openstack.glance.os_type" = "linux"
+      "org.openstack.glance.architecture" = "x86_64"
+      "eu.egi.cloud.description" = "EGI Ubuntu 26.04 image"
+    }
+  }
+}


### PR DESCRIPTION
Adds a Packer template for **Ubuntu 26.04 LTS (Resolute Raccoon)**, mirroring the existing `ubuntu-24.04.pkr.hcl`.

- Builds from the official 26.04 live-server ISO (`https://releases.ubuntu.com/26.04/ubuntu-26.04-live-server-amd64.iso`); the `sha256` was verified against the published `SHA256SUMS`.
- Reuses the existing autoinstall seed (`httpdir`) and the `init` / `base` / `cleanup` provisioners — only the ISO, the source/VM name, the Glance `os_version`, and the description differ from 24.04.
- No CI changes needed: `build-changes.yml` builds changed `*.hcl` on PRs and `trigger-build.yml` globs all templates, so 26.04 is picked up automatically.

26.04 LTS (released 2026-04) gives the VOs the longest support runway.
